### PR TITLE
update README

### DIFF
--- a/README
+++ b/README
@@ -12,10 +12,10 @@ HikiDoc requires Ruby 1.8.2 or later.
 
 !! Download
 
-Get from the subversion repository http://hikidoc.rubyforge.org/svn/ .
+Get from the GitHub repository https://github.com/hiki/hikidoc
 
  (eg.)
- svn co http://hikidoc.rubyforge.org/svn/trunk/ hikidoc
+ git clone https://github.com/hiki/hikidoc.git
 
 !! Installation
 

--- a/README.ja
+++ b/README.ja
@@ -11,11 +11,11 @@ HikiDoc の実行には Ruby 1.8.2 以降が必要です。
 
 !! ダウンロード
 
-Subversion レポジトリ http://hikidoc.rubyforge.org/svn/ から取得して
+GitHub レポジトリ https://github.com/hiki/hikidoc から取得して
 ください。
 
  (例)
- svn co http://hikidoc.rubyforge.org/svn/trunk/ hikidoc
+ git clone https://github.com/hiki/hikidoc.git
 
 !! インストール
 


### PR DESCRIPTION
I've found dead links in READMEs.
revised the Download section of README, as rubyforge.org is not available anymore.