### PR TITLE
add an explanation about installation via RubyGems to READMEs

### DIFF
--- a/README
+++ b/README
@@ -19,11 +19,19 @@ Get from the subversion repository http://hikidoc.rubyforge.org/svn/ .
 
 !! Installation
 
+!!! Semi-manual installation
+
 Run the 'setup.rb' script like so:
 
  $ ruby setup.rb config
  $ ruby setup.rb setup
  # ruby setup.rb install
+
+!!! Installation via RubyGems
+
+Run the following command:
+
+ $ gem install hikidoc
 
 !! Syntax
 

--- a/README.ja
+++ b/README.ja
@@ -19,11 +19,19 @@ Subversion レポジトリ http://hikidoc.rubyforge.org/svn/ から取得して
 
 !! インストール
 
+!!! 半手動でのインストール
+
 以下のように 'setup.rb' スクリプトを用いてインストールします。
 
  $ ruby setup.rb config
  $ ruby setup.rb setup
  # ruby setup.rb install
+
+!!! RubyGems経由でのインストール
+
+以下のようにインストールします。
+
+ $ gem install hikidoc
 
 !! 文法
 


### PR DESCRIPTION
By adding a metion about RubyGems, users would not need to check if hikidoc is already published to RubyGems.org