### PR TITLE
Bug fix for syntax to escape Wikinames

### DIFF
--- a/TextFormattingRules.md
+++ b/TextFormattingRules.md
@@ -62,7 +62,7 @@ WikiName     - WikiName
 <ul>
 <li><ul>
 <li><a href="WikiName">WikiName</a>     - <a href="WikiName">WikiName</a></li>
-<li>WikiName    - Disable WikiName link    - Disable <a href="WikiName">WikiName</a> link</li>
+<li>WikiName    - Disable <a href="WikiName">WikiName</a> link</li>
 </ul></li>
 </ul>
 

--- a/lib/hikidoc.rb
+++ b/lib/hikidoc.rb
@@ -405,7 +405,7 @@ class HikiDoc
       str = m.post_match
 
       link, uri, mod, wiki_name = m[1, 4]
-      if wiki_name and wiki_name[0, 1] == "^"
+      if wiki_name and wiki_name.start_with? "^"
         pending_str += m.pre_match + wiki_name[1..-1]
         next
       end
@@ -415,8 +415,7 @@ class HikiDoc
       evaluate_plugin_block(pre_str, buf)
       compile_inline_markup(buf, link, uri, mod, wiki_name)
     end
-    pending_str = pending_str.empty? ? nil : pending_str + str
-    evaluate_plugin_block(pending_str || str, buf)
+    evaluate_plugin_block(pending_str + str, buf)
     buf
   end
 

--- a/lib/hikidoc.rb
+++ b/lib/hikidoc.rb
@@ -400,21 +400,22 @@ class HikiDoc
   def compile_inline(str, buf = nil)
     buf ||= @output.container
     re = inline_syntax_re
-    pending_str = nil
+    pending_str = ""
     while m = re.match(str)
       str = m.post_match
 
       link, uri, mod, wiki_name = m[1, 4]
       if wiki_name and wiki_name[0, 1] == "^"
-        pending_str = m.pre_match + wiki_name[1..-1] + str
+        pending_str += m.pre_match + wiki_name[1..-1]
         next
       end
 
       pre_str = "#{pending_str}#{m.pre_match}"
-      pending_str = nil
+      pending_str = ""
       evaluate_plugin_block(pre_str, buf)
       compile_inline_markup(buf, link, uri, mod, wiki_name)
     end
+    pending_str = pending_str.empty? ? nil : pending_str + str
     evaluate_plugin_block(pending_str || str, buf)
     buf
   end

--- a/test/hikidoc_test.rb
+++ b/test/hikidoc_test.rb
@@ -303,7 +303,12 @@ TEST}}
                    "foo ^WikiName bar")
     assert_convert("<p>WikiName - Disable <a href=\"WikiName\">WikiName</a> link</p>\n",
                    "^WikiName - Disable WikiName link")
-
+    assert_convert("<p><a href=\"WikiName\">WikiName</a> - Disable DisabledWikiName link</p>\n",
+                   "WikiName - Disable ^DisabledWikiName link")
+    assert_convert("<p><a href=\"WikiName\">WikiName</a> - Disable <a href=\"WikiName\">WikiName</a> link</p>\n",
+                   "WikiName - Disable WikiName link")
+    assert_convert("<p>DisabledWikiName - Disable DisabledWikiName link</p>\n",
+                   "^DisabledWikiName - Disable ^DisabledWikiName link")
   end
 
   def test_use_wiki_name_option

--- a/test/hikidoc_test.rb
+++ b/test/hikidoc_test.rb
@@ -301,6 +301,9 @@ TEST}}
                    use_not_wiki_name: false)
     assert_convert("<p>foo WikiName bar</p>\n",
                    "foo ^WikiName bar")
+    assert_convert("<p>WikiName - Disable <a href=\"WikiName\">WikiName</a> link</p>\n",
+                   "^WikiName - Disable WikiName link")
+
   end
 
   def test_use_wiki_name_option


### PR DESCRIPTION
Sorry, I should have noticed earlier, but I found the example output of

```
 ^WikiName    - Disable WikiName link
```

in TextFormattingRules.md was not

```
<li>WikiName - Disable <a href="WikiName">WikiName</a> link</li>
```

but

```
<li>WikiName - Disable WikiName link    - Disable <a href="WikiName">WikiName</a> link</li>
```
