### PR TITLE
Fix command error handling

### DIFF
--- a/bin/hikidoc
+++ b/bin/hikidoc
@@ -46,7 +46,7 @@ when 0
 when 1
   title, text = ARGV[0], File.read(ARGV[0])
 else
-  usage
+  abort usage
 end
 
 body = HikiDoc.to_html(text, format_options)

--- a/bin/hikidoc
+++ b/bin/hikidoc
@@ -46,7 +46,7 @@ when 0
 when 1
   title, text = ARGV[0], File.read(ARGV[0])
 else
-  abort usage
+  abort ARGV.options.help
 end
 
 body = HikiDoc.to_html(text, format_options)

--- a/bin/hikidoc
+++ b/bin/hikidoc
@@ -16,10 +16,14 @@ HTML_TEMPLATE = <<EOS
 </html>
 EOS
 
+def usage
+  "Usage: #$0 [OPTIONS] FILE"
+end
+
 options = {}
 format_options = {}
 ARGV.options do |opts|
-  opts.banner = "Usage: #$0 [OPTIONS] FILE"
+  opts.banner = usage
 
   opts.on('-f', '--fragment',
           'Output HTML fragments only') do


### PR DESCRIPTION
Hi,

Is this gem still maintained?

I encountered an error below when I pass more than one arguments to `hikidoc` command.

    NameError: undefined local variable or method `usage' for main:Object
      bin/hikidoc:45:in `<top (required)>'

So, I fixed the command. Could you consider?

Thanks.